### PR TITLE
Adds distro-read function to Jabba.

### DIFF
--- a/jabba.go
+++ b/jabba.go
@@ -84,3 +84,11 @@ func AddUser(user User) {
 		Perm:     0644,
 	})
 }
+
+func DistroString() (distro string) {
+	thistro, err := exec.Command("lsb_release", "-cs").Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return string(thistro)
+}


### PR DESCRIPTION
I took the distro-reading function that was being reused on several config components, and moved it here. This will need merged before https://github.com/Prismatik/config/pull/4 
